### PR TITLE
[WIP] Feat: record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4027,6 +4027,22 @@ dependencies = [
 [[package]]
 name = "stakedex_index"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "borsh 0.9.3",
+ "jupiter-core",
+ "solana-program",
+ "solana-sdk",
+ "stakedex_eversol_stake_pool",
+ "stakedex_interface",
+ "stakedex_lido",
+ "stakedex_marinade",
+ "stakedex_sdk_common",
+ "stakedex_socean_stake_pool",
+ "stakedex_spl_stake_pool",
+ "stakedex_unstake_it",
+]
 
 [[package]]
 name = "stakedex_interface"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4025,6 +4025,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "stakedex_index"
+version = "0.1.0"
+
+[[package]]
 name = "stakedex_interface"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "stakedex_sdk",
     "common",
+    "index",
     "libs/*",
     "interfaces/*"
 ]

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -6,3 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = { workspace = true }
+bincode = { workspace = true }
+borsh = { workspace = true }
+jupiter-core = { workspace = true }
+solana-program = { workspace = true }
+solana-sdk = { workspace = true }
+stakedex_eversol_stake_pool = { workspace = true }
+stakedex_interface = { workspace = true }
+stakedex_lido = { workspace = true }
+stakedex_marinade = { workspace = true }
+stakedex_sdk_common = { workspace = true }
+stakedex_socean_stake_pool = { workspace = true }
+stakedex_spl_stake_pool = { workspace = true }
+stakedex_unstake_it = { workspace = true }

--- a/index/Cargo.toml
+++ b/index/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "stakedex_index"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/index/README.md
+++ b/index/README.md
@@ -1,0 +1,7 @@
+# stakedex_index
+
+Serde format for storing and decoding on-chain xSOL swaps data
+
+## Overview
+
+To allow dynamic discovery of swap pairs, data required to construct the stake pool structs for each pair is stored on-chain via the `RecordDex` instruction that creates an immutable record of this data on-chain in a `DexRecord` account.

--- a/index/src/deposit_sol.rs
+++ b/index/src/deposit_sol.rs
@@ -1,0 +1,29 @@
+use jupiter_core::amm::{Amm, KeyedAccount};
+use stakedex_eversol_stake_pool::EversolStakePoolStakedex;
+use stakedex_interface::DepositSolType;
+use stakedex_lido::LidoStakedex;
+use stakedex_marinade::MarinadeStakedex;
+use stakedex_sdk_common::{DepositSol, DepositSolWrapper, InitFromKeyedAccount};
+use stakedex_socean_stake_pool::SoceanStakePoolStakedex;
+use stakedex_spl_stake_pool::SplStakePoolStakedex;
+
+pub fn load_deposit_sol(
+    ty: &DepositSolType,
+    main_account: &KeyedAccount,
+) -> Result<Box<dyn Amm>, anyhow::Error> {
+    match ty {
+        DepositSolType::Eversol => load_pool::<EversolStakePoolStakedex>(main_account),
+        DepositSolType::Lido => load_pool::<LidoStakedex>(main_account),
+        DepositSolType::Marinade => load_pool::<MarinadeStakedex>(main_account),
+        DepositSolType::Socean => load_pool::<SoceanStakePoolStakedex>(main_account),
+        DepositSolType::Spl => load_pool::<SplStakePoolStakedex>(main_account),
+    }
+}
+
+fn load_pool<P: InitFromKeyedAccount + DepositSol + Clone + Send + Sync + 'static>(
+    main_account: &KeyedAccount,
+) -> Result<Box<dyn Amm>, anyhow::Error> {
+    Ok(Box::new(DepositSolWrapper(P::from_keyed_account(
+        main_account,
+    )?)))
+}

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/index/src/lib.rs
+++ b/index/src/lib.rs
@@ -1,14 +1,128 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
+use std::collections::HashMap;
+
+use jupiter_core::amm::{Amm, KeyedAccount};
+use solana_program::{
+    clock::Clock,
+    pubkey::Pubkey,
+    sysvar::{self, clock},
+};
+use stakedex_interface::{
+    DexRecord, DexRecordAccount, DexRecordDepositSol, DexRecordOneWayPoolPair,
+    DexRecordTwoWayPoolPair,
+};
+
+mod deposit_sol;
+mod one_way_pool_pair;
+mod two_way_pool_pair;
+
+pub use deposit_sol::*;
+pub use one_way_pool_pair::*;
+pub use two_way_pool_pair::*;
+
+pub fn init_accounts_to_fetch(dex_record: &DexRecordAccount) -> Vec<Pubkey> {
+    match &dex_record.record {
+        DexRecord::DepositSol(s) => init_accounts_to_fetch_deposit_sol(s).to_vec(),
+        DexRecord::OneWayPoolPair(s) => init_accounts_to_fetch_one_way_pool_pair(s).to_vec(),
+        DexRecord::TwoWayPoolPair(s) => init_accounts_to_fetch_two_way_pool_pair(s).to_vec(),
+    }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+fn init_accounts_to_fetch_deposit_sol(s: &DexRecordDepositSol) -> [Pubkey; 1] {
+    [s.main_account]
+}
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+fn init_accounts_to_fetch_one_way_pool_pair(s: &DexRecordOneWayPoolPair) -> [Pubkey; 3] {
+    [
+        s.withdraw_stake_main_account,
+        s.deposit_stake_main_account,
+        clock::ID,
+    ]
+}
+
+fn init_accounts_to_fetch_two_way_pool_pair(s: &DexRecordTwoWayPoolPair) -> [Pubkey; 3] {
+    [s.a_main_account, s.b_main_account, clock::ID]
+}
+
+fn get_keyed_account(
+    accounts_map: &HashMap<Pubkey, solana_sdk::account::Account>,
+    key: &Pubkey,
+) -> Result<KeyedAccount, anyhow::Error> {
+    Ok(KeyedAccount {
+        key: *key,
+        account: accounts_map
+            .get(key)
+            .ok_or_else(|| anyhow::anyhow!("Missing account {}", key))?
+            .clone(),
+        params: None,
+    })
+}
+
+pub fn init_amm(
+    dex_record: &DexRecordAccount,
+    accounts_map: &HashMap<Pubkey, solana_sdk::account::Account>,
+) -> Result<Box<dyn Amm>, anyhow::Error> {
+    match &dex_record.record {
+        DexRecord::DepositSol(s) => init_deposit_sol(s, accounts_map),
+        DexRecord::OneWayPoolPair(s) => init_one_way_pool_pair(s, accounts_map),
+        DexRecord::TwoWayPoolPair(s) => init_two_way_pool_pair(s, accounts_map),
     }
+}
+
+fn init_deposit_sol(
+    dex_record_deposit_sol: &DexRecordDepositSol,
+    accounts_map: &HashMap<Pubkey, solana_sdk::account::Account>,
+) -> Result<Box<dyn Amm>, anyhow::Error> {
+    let main_account_pk = init_accounts_to_fetch_deposit_sol(dex_record_deposit_sol)[0];
+    let main_account = get_keyed_account(accounts_map, &main_account_pk)?;
+    load_deposit_sol(&dex_record_deposit_sol.ty, &main_account)
+}
+
+fn init_one_way_pool_pair(
+    dex_record_one_way_pool_pair: &DexRecordOneWayPoolPair,
+    accounts_map: &HashMap<Pubkey, solana_sdk::account::Account>,
+) -> Result<Box<dyn Amm>, anyhow::Error> {
+    let keys = init_accounts_to_fetch_one_way_pool_pair(dex_record_one_way_pool_pair);
+    let withdraw_stake_main_account_pk = keys[0];
+    let deposit_stake_main_account_pk = keys[1];
+
+    let clock_acc = accounts_map
+        .get(&sysvar::clock::ID)
+        .ok_or_else(|| anyhow::anyhow!("Missing account clock"))?;
+    let clock: Clock = bincode::deserialize(clock_acc.data.as_ref())?;
+
+    let withdraw_stake_main_account =
+        get_keyed_account(accounts_map, &withdraw_stake_main_account_pk)?;
+    let deposit_stake_main_account =
+        get_keyed_account(accounts_map, &deposit_stake_main_account_pk)?;
+    load_one_way_pool_pair(
+        &dex_record_one_way_pool_pair.withdraw_stake_ty,
+        &withdraw_stake_main_account,
+        &dex_record_one_way_pool_pair.deposit_stake_ty,
+        &deposit_stake_main_account,
+        clock,
+    )
+}
+
+fn init_two_way_pool_pair(
+    dex_record_two_way_pool_pair: &DexRecordTwoWayPoolPair,
+    accounts_map: &HashMap<Pubkey, solana_sdk::account::Account>,
+) -> Result<Box<dyn Amm>, anyhow::Error> {
+    let keys = init_accounts_to_fetch_two_way_pool_pair(dex_record_two_way_pool_pair);
+    let a_main_account_pk = keys[0];
+    let b_main_account_pk = keys[1];
+
+    let clock_acc = accounts_map
+        .get(&sysvar::clock::ID)
+        .ok_or_else(|| anyhow::anyhow!("Missing account clock"))?;
+    let clock: Clock = bincode::deserialize(clock_acc.data.as_ref())?;
+
+    let a_main_account = get_keyed_account(accounts_map, &a_main_account_pk)?;
+    let b_main_account = get_keyed_account(accounts_map, &b_main_account_pk)?;
+    load_two_way_pool_pair(
+        &dex_record_two_way_pool_pair.a_ty,
+        &a_main_account,
+        &dex_record_two_way_pool_pair.b_ty,
+        &b_main_account,
+        clock,
+    )
 }

--- a/index/src/one_way_pool_pair.rs
+++ b/index/src/one_way_pool_pair.rs
@@ -1,0 +1,96 @@
+use jupiter_core::amm::{Amm, KeyedAccount};
+use solana_program::clock::Clock;
+use stakedex_eversol_stake_pool::EversolStakePoolStakedex;
+use stakedex_interface::{DepositStakeType, WithdrawStakeType};
+use stakedex_lido::LidoStakedex;
+use stakedex_marinade::MarinadeStakedex;
+use stakedex_sdk_common::{DepositStake, InitFromKeyedAccount, OneWayPoolPair, WithdrawStake};
+use stakedex_socean_stake_pool::SoceanStakePoolStakedex;
+use stakedex_spl_stake_pool::SplStakePoolStakedex;
+use stakedex_unstake_it::UnstakeItStakedex;
+
+macro_rules! match_deposit {
+    ($w: ty, $withdraw_stake_main_account: expr, $deposit_stake_ty: expr, $deposit_stake_main_account: expr, $clock: expr) => {
+        match $deposit_stake_ty {
+            DepositStakeType::Eversol => load_pool_pair::<$w, EversolStakePoolStakedex>(
+                $withdraw_stake_main_account,
+                $deposit_stake_main_account,
+                $clock,
+            ),
+            DepositStakeType::Marinade => load_pool_pair::<$w, MarinadeStakedex>(
+                $withdraw_stake_main_account,
+                $deposit_stake_main_account,
+                $clock,
+            ),
+            DepositStakeType::Socean => load_pool_pair::<$w, SoceanStakePoolStakedex>(
+                $withdraw_stake_main_account,
+                $deposit_stake_main_account,
+                $clock,
+            ),
+            DepositStakeType::Spl => load_pool_pair::<$w, SplStakePoolStakedex>(
+                $withdraw_stake_main_account,
+                $deposit_stake_main_account,
+                $clock,
+            ),
+            DepositStakeType::Unstakeit => load_pool_pair::<$w, UnstakeItStakedex>(
+                $withdraw_stake_main_account,
+                $deposit_stake_main_account,
+                $clock,
+            ),
+        }
+    };
+}
+
+pub fn load_one_way_pool_pair(
+    withdraw_stake_ty: &WithdrawStakeType,
+    withdraw_stake_main_account: &KeyedAccount,
+    deposit_stake_ty: &DepositStakeType,
+    deposit_stake_main_account: &KeyedAccount,
+    clock: Clock,
+) -> Result<Box<dyn Amm>, anyhow::Error> {
+    match withdraw_stake_ty {
+        WithdrawStakeType::Eversol => match_deposit!(
+            EversolStakePoolStakedex,
+            withdraw_stake_main_account,
+            deposit_stake_ty,
+            deposit_stake_main_account,
+            clock
+        ),
+        WithdrawStakeType::Lido => match_deposit!(
+            LidoStakedex,
+            withdraw_stake_main_account,
+            deposit_stake_ty,
+            deposit_stake_main_account,
+            clock
+        ),
+        WithdrawStakeType::Socean => match_deposit!(
+            SoceanStakePoolStakedex,
+            withdraw_stake_main_account,
+            deposit_stake_ty,
+            deposit_stake_main_account,
+            clock
+        ),
+        WithdrawStakeType::Spl => match_deposit!(
+            SplStakePoolStakedex,
+            withdraw_stake_main_account,
+            deposit_stake_ty,
+            deposit_stake_main_account,
+            clock
+        ),
+    }
+}
+
+fn load_pool_pair<
+    W: InitFromKeyedAccount + WithdrawStake + Clone + Send + Sync + 'static,
+    D: InitFromKeyedAccount + DepositStake + Clone + Send + Sync + 'static,
+>(
+    withdraw_stake_main_account: &KeyedAccount,
+    deposit_stake_main_account: &KeyedAccount,
+    clock: Clock,
+) -> Result<Box<dyn Amm>, anyhow::Error> {
+    Ok(Box::new(OneWayPoolPair {
+        withdraw: W::from_keyed_account(withdraw_stake_main_account)?,
+        deposit: D::from_keyed_account(deposit_stake_main_account)?,
+        clock,
+    }))
+}

--- a/index/src/two_way_pool_pair.rs
+++ b/index/src/two_way_pool_pair.rs
@@ -1,0 +1,74 @@
+use jupiter_core::amm::{Amm, KeyedAccount};
+use solana_program::clock::Clock;
+use stakedex_eversol_stake_pool::EversolStakePoolStakedex;
+use stakedex_interface::DepositWithdrawStakeType;
+use stakedex_sdk_common::{DepositStake, InitFromKeyedAccount, TwoWayPoolPair, WithdrawStake};
+use stakedex_socean_stake_pool::SoceanStakePoolStakedex;
+use stakedex_spl_stake_pool::SplStakePoolStakedex;
+
+macro_rules! match_b {
+    ($a: ty, $a_main_account: expr, $b_ty: expr, $b_main_account: expr, $clock: expr) => {
+        match $b_ty {
+            DepositWithdrawStakeType::Eversol => load_pool_pair::<$a, EversolStakePoolStakedex>(
+                $a_main_account,
+                $b_main_account,
+                $clock,
+            ),
+            DepositWithdrawStakeType::Socean => load_pool_pair::<$a, SoceanStakePoolStakedex>(
+                $a_main_account,
+                $b_main_account,
+                $clock,
+            ),
+            DepositWithdrawStakeType::Spl => {
+                load_pool_pair::<$a, SplStakePoolStakedex>($a_main_account, $b_main_account, $clock)
+            }
+        }
+    };
+}
+
+pub fn load_two_way_pool_pair(
+    a_ty: &DepositWithdrawStakeType,
+    a_main_account: &KeyedAccount,
+    b_ty: &DepositWithdrawStakeType,
+    b_main_account: &KeyedAccount,
+    clock: Clock,
+) -> Result<Box<dyn Amm>, anyhow::Error> {
+    match a_ty {
+        DepositWithdrawStakeType::Eversol => match_b!(
+            EversolStakePoolStakedex,
+            a_main_account,
+            b_ty,
+            b_main_account,
+            clock
+        ),
+        DepositWithdrawStakeType::Socean => match_b!(
+            SoceanStakePoolStakedex,
+            a_main_account,
+            b_ty,
+            b_main_account,
+            clock
+        ),
+        DepositWithdrawStakeType::Spl => match_b!(
+            SplStakePoolStakedex,
+            a_main_account,
+            b_ty,
+            b_main_account,
+            clock
+        ),
+    }
+}
+
+fn load_pool_pair<
+    P1: InitFromKeyedAccount + DepositStake + WithdrawStake + Clone + Send + Sync + 'static,
+    P2: InitFromKeyedAccount + DepositStake + WithdrawStake + Clone + Send + Sync + 'static,
+>(
+    main_account_withdraw: &KeyedAccount,
+    main_account_deposit: &KeyedAccount,
+    clock: Clock,
+) -> Result<Box<dyn Amm>, anyhow::Error> {
+    Ok(Box::new(TwoWayPoolPair {
+        p1: P1::from_keyed_account(main_account_withdraw)?,
+        p2: P2::from_keyed_account(main_account_deposit)?,
+        clock,
+    }))
+}

--- a/interfaces/stakedex_interface/idl.json
+++ b/interfaces/stakedex_interface/idl.json
@@ -297,9 +297,159 @@
         "type": "u8",
         "value": 5
       }
+    },
+    {
+      "name": "RecordDex",
+      "accounts": [
+        {
+          "name": "recordAuth",
+          "isMut": false,
+          "isSigner": true,
+          "desc": "The record authority"
+        },
+        {
+          "name": "payer",
+          "isMut": true,
+          "isSigner": true,
+          "desc": "The payer for the new record account's rent"
+        },
+        {
+          "name": "dexRecord",
+          "isMut": true,
+          "isSigner": false,
+          "desc": "The dex record account to write to. PDA. Seeds = DexRecord::pda()"
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "recordDexArgs",
+          "type": {
+            "defined": "RecordDexArgs"
+          }
+        }
+      ],
+      "discriminant": {
+        "type": "u8",
+        "value": 6
+      }
+    }
+  ],
+  "accounts": [
+    {
+      "name": "DexRecordAccount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "record",
+            "type": {
+              "defined": "DexRecord"
+            }
+          }
+        ]
+      }
     }
   ],
   "types": [
+    {
+      "name": "DexRecordDepositSol",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "ty",
+            "type": {
+              "defined": "DepositSolType"
+            }
+          },
+          {
+            "name": "mint",
+            "type": "publicKey"
+          },
+          {
+            "name": "mainAccount",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DexRecordOneWayPoolPair",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "withdrawStakeTy",
+            "type": {
+              "defined": "WithdrawStakeType"
+            }
+          },
+          {
+            "name": "depositStakeTy",
+            "type": {
+              "defined": "DepositStakeType"
+            }
+          },
+          {
+            "name": "withdrawStakeMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "depositStakeMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "withdrawStakeMainAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "depositStakeMainAccount",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DexRecordTwoWayPoolPair",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "aTy",
+            "type": {
+              "defined": "DepositWithdrawStakeType"
+            }
+          },
+          {
+            "name": "bTy",
+            "type": {
+              "defined": "DepositWithdrawStakeType"
+            }
+          },
+          {
+            "name": "aMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "bMint",
+            "type": "publicKey"
+          },
+          {
+            "name": "aMainAccount",
+            "type": "publicKey"
+          },
+          {
+            "name": "bMainAccount",
+            "type": "publicKey"
+          }
+        ]
+      }
+    },
     {
       "name": "StakeWrappedSolArgs",
       "type": {
@@ -327,12 +477,139 @@
           }
         ]
       }
+    },
+    {
+      "name": "RecordDexArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "dexRecord",
+            "type": {
+              "defined": "DexRecord"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "DexRecord",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "DepositSol",
+            "fields": [
+              {
+                "defined": "DexRecordDepositSol"
+              }
+            ]
+          },
+          {
+            "name": "OneWayPoolPair",
+            "fields": [
+              {
+                "defined": "DexRecordOneWayPoolPair"
+              }
+            ]
+          },
+          {
+            "name": "TwoWayPoolPair",
+            "fields": [
+              {
+                "defined": "DexRecordTwoWayPoolPair"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositSolType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Eversol"
+          },
+          {
+            "name": "Lido"
+          },
+          {
+            "name": "Marinade"
+          },
+          {
+            "name": "Socean"
+          },
+          {
+            "name": "Spl"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositStakeType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Eversol"
+          },
+          {
+            "name": "Marinade"
+          },
+          {
+            "name": "Socean"
+          },
+          {
+            "name": "Spl"
+          },
+          {
+            "name": "Unstakeit"
+          }
+        ]
+      }
+    },
+    {
+      "name": "WithdrawStakeType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Eversol"
+          },
+          {
+            "name": "Lido"
+          },
+          {
+            "name": "Socean"
+          },
+          {
+            "name": "Spl"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DepositWithdrawStakeType",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Eversol"
+          },
+          {
+            "name": "Socean"
+          },
+          {
+            "name": "Spl"
+          }
+        ]
+      }
     }
   ],
   "metadata": {
     "origin": "shank",
-    "address": "stkitrT1Uoy18Dk1fTrgPw8W6MVzoCfYoAFT4MLsmhq",
-    "binaryVersion": "0.0.11",
-    "libVersion": "0.0.11"
+    "address": "stkitrT1Uoy18Dk1fTrgPw8W6MVzoCfYoAFT4MLsmhq"
   }
 }

--- a/interfaces/stakedex_interface/src/accounts.rs
+++ b/interfaces/stakedex_interface/src/accounts.rs
@@ -1,0 +1,6 @@
+use crate::*;
+use borsh::{BorshDeserialize, BorshSerialize};
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
+pub struct DexRecordAccount {
+    pub record: DexRecord,
+}

--- a/interfaces/stakedex_interface/src/lib.rs
+++ b/interfaces/stakedex_interface/src/lib.rs
@@ -1,4 +1,6 @@
 solana_program::declare_id!("stkitrT1Uoy18Dk1fTrgPw8W6MVzoCfYoAFT4MLsmhq");
+pub mod accounts;
+pub use accounts::*;
 pub mod instructions;
 pub use instructions::*;
 pub mod typedefs;

--- a/interfaces/stakedex_interface/src/typedefs.rs
+++ b/interfaces/stakedex_interface/src/typedefs.rs
@@ -1,4 +1,29 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+use solana_program::pubkey::Pubkey;
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
+pub struct DexRecordDepositSol {
+    pub ty: DepositSolType,
+    pub mint: Pubkey,
+    pub main_account: Pubkey,
+}
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
+pub struct DexRecordOneWayPoolPair {
+    pub withdraw_stake_ty: WithdrawStakeType,
+    pub deposit_stake_ty: DepositStakeType,
+    pub withdraw_stake_mint: Pubkey,
+    pub deposit_stake_mint: Pubkey,
+    pub withdraw_stake_main_account: Pubkey,
+    pub deposit_stake_main_account: Pubkey,
+}
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
+pub struct DexRecordTwoWayPoolPair {
+    pub a_ty: DepositWithdrawStakeType,
+    pub b_ty: DepositWithdrawStakeType,
+    pub a_mint: Pubkey,
+    pub b_mint: Pubkey,
+    pub a_main_account: Pubkey,
+    pub b_main_account: Pubkey,
+}
 #[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
 pub struct StakeWrappedSolArgs {
     pub amount: u64,
@@ -7,4 +32,43 @@ pub struct StakeWrappedSolArgs {
 pub struct SwapViaStakeArgs {
     pub amount: u64,
     pub bridge_stake_seed: u32,
+}
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
+pub struct RecordDexArgs {
+    pub dex_record: DexRecord,
+}
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
+pub enum DexRecord {
+    DepositSol(DexRecordDepositSol),
+    OneWayPoolPair(DexRecordOneWayPoolPair),
+    TwoWayPoolPair(DexRecordTwoWayPoolPair),
+}
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
+pub enum DepositSolType {
+    Eversol,
+    Lido,
+    Marinade,
+    Socean,
+    Spl,
+}
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
+pub enum DepositStakeType {
+    Eversol,
+    Marinade,
+    Socean,
+    Spl,
+    Unstakeit,
+}
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
+pub enum WithdrawStakeType {
+    Eversol,
+    Lido,
+    Socean,
+    Spl,
+}
+#[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
+pub enum DepositWithdrawStakeType {
+    Eversol,
+    Socean,
+    Spl,
 }


### PR DESCRIPTION
Related:
- https://github.com/igneous-labs/stakedex/pull/1
- https://github.com/igneous-labs/stakedex-cli/pull/1

New instruction to record dex entry records on-chain for jup.

Pretty much completed, but kinda pointless until jup figures out how to integrate stakedex without messing up their routing due to the "pool_visited flag" being incompatible with each stakedex entry possibly comprising 2 pools